### PR TITLE
Add progress bar

### DIFF
--- a/client/src/components/TotalsDisplay.js
+++ b/client/src/components/TotalsDisplay.js
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { Container } from "react-bootstrap";
+import { Container, ProgressBar } from "react-bootstrap";
 import Card from "react-bootstrap/Card";
 import { useSelector, useDispatch } from "react-redux";
 import { updateNetIncome } from "../state/action-creators/netIncomeActionCreators";
@@ -39,8 +39,18 @@ const TotalsDisplay = () => {
                     <h3>Total Expenses</h3>
                     <h4><CountUp end={totalExpenses} prefix="$" suffix=" /year" separator="," decimals={2} preserveValue /></h4>
                     <h3>Net Income</h3>
-                    <h4><CountUp end={netIncome} prefix="$" separator="," decimals={2} preserveValue
-                        style={{ color: netIncome >= 0 ? "#262833" : "red" }} /> /year</h4>
+                    <h4>
+                        <CountUp
+                            end={netIncome}
+                            prefix="$"
+                            separator=","
+                            decimals={2}
+                            preserveValue
+                            style={{ color: netIncome >= 0 ? "#262833" : "red" }}
+                        />
+                        /year
+                    </h4>
+                    <ProgressBar now={((totalExpenses + tax) / grossIncome) * 100} />
                 </Card.Body>
             </Card>
         </Container>

--- a/client/src/components/TotalsDisplay.js
+++ b/client/src/components/TotalsDisplay.js
@@ -18,6 +18,16 @@ const TotalsDisplay = () => {
         dispatch(updateNetIncome(netIncome));
     });
 
+    const updateProgressBar = (grossIncome, totalExpenses, tax) => {
+        if(grossIncome === 0 && totalExpenses > 0) {
+            return 100;
+        } else if(grossIncome === 0 && totalExpenses === 0) {
+            return 0;
+        } else {
+            return totalExpenses / (grossIncome - tax) * 100;
+        };
+    };
+
     return (
         <Container>
             <Card className="bg-primary border-light shadow-soft">
@@ -51,7 +61,7 @@ const TotalsDisplay = () => {
                     </h4>
                     <ProgressBar
                         variant={(totalExpenses / (grossIncome - tax) * 100) < 100 ? null : "danger"}
-                        now={totalExpenses / (grossIncome - tax) * 100}
+                        now={updateProgressBar(grossIncome, totalExpenses, tax)}
                     />
                 </Card.Body>
             </Card>

--- a/client/src/components/TotalsDisplay.js
+++ b/client/src/components/TotalsDisplay.js
@@ -50,7 +50,10 @@ const TotalsDisplay = () => {
                         />
                         /year
                     </h4>
-                    <ProgressBar now={((totalExpenses + tax) / grossIncome) * 100} />
+                    <ProgressBar
+                        variant={(totalExpenses / (grossIncome - tax) * 100) < 100 ? null : "danger"}
+                        now={totalExpenses / (grossIncome - tax) * 100}
+                    />
                 </Card.Body>
             </Card>
         </Container>

--- a/client/src/components/TotalsDisplay.js
+++ b/client/src/components/TotalsDisplay.js
@@ -47,8 +47,7 @@ const TotalsDisplay = () => {
                             decimals={2}
                             preserveValue
                             style={{ color: netIncome >= 0 ? "#262833" : "red" }}
-                        />
-                        /year
+                        /> /year
                     </h4>
                     <ProgressBar
                         variant={(totalExpenses / (grossIncome - tax) * 100) < 100 ? null : "danger"}

--- a/client/src/scss/neumorphism/components/_card.scss
+++ b/client/src/scss/neumorphism/components/_card.scss
@@ -14,6 +14,7 @@
 
 .card {
     position: relative;
+    border-radius: 25px;
     .card-header{
         background: transparent;
     }

--- a/client/src/scss/neumorphism/components/_progress.scss
+++ b/client/src/scss/neumorphism/components/_progress.scss
@@ -9,11 +9,13 @@
 .progress-bar {
     box-shadow: none;
     height: auto;
+    background-color: $secondary;
     @include border-radius($badge-border-radius);
 }
 
 .progress {
-    height: .6rem;
+    // height originally .6rem
+    height: 2rem;
     border: $border-width solid $light;
     margin-bottom: $spacer;
     overflow: hidden;


### PR DESCRIPTION
closes #27 

- Added a progress bar that visually displays how much income has been eaten by expenses
- it's seafoam green because it's a pretty colour
- it turns danger red if your expenses exceed your income!
- technically out of the scope of this PR but I changed `border-radius` of the cards to `25px`