### PR TITLE
Fix net income calculation

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -111,12 +111,12 @@ function App() {
 									<label className="custom-control-label" htmlFor="taxSwitch">Disable Tax</label>
 								</div>
 							</Dropdown.Item>
-							<Dropdown.Item as="div">
+							{/* <Dropdown.Item as="div">
 								<div className="custom-control custom-switch">
 									<input type="checkbox" className="custom-control-input" disabled id="darkMode" />
 									<label className="custom-control-label" htmlFor="darkMode">Dark Mode</label>
 								</div>
-							</Dropdown.Item>
+							</Dropdown.Item> */}
 						</Dropdown.Menu>
 					</Dropdown>
 				</div>

--- a/client/src/components/TotalsDisplay.js
+++ b/client/src/components/TotalsDisplay.js
@@ -12,10 +12,9 @@ const TotalsDisplay = () => {
     const totalExpenses = useSelector((state) => state.totalExpenses.totalExpenses);
     const isIgnoringTax = useSelector((state) => state.preferences.isIgnoringTax);
     const dispatch = useDispatch();
-    const strike = isIgnoringTax ? "hidden" : null;
 
     useEffect(() => {
-        const netIncome = isIgnoringTax ? grossIncome - totalExpenses : grossIncome - (totalExpenses - tax);
+        const netIncome = isIgnoringTax ? grossIncome - totalExpenses : grossIncome - (totalExpenses + tax);
         window.localStorage.setItem("netIncome", JSON.stringify(netIncome));
         dispatch(updateNetIncome(netIncome));
     });
@@ -31,8 +30,6 @@ const TotalsDisplay = () => {
             return totalExpenses / (grossIncome - tax) * 100;
         };
     };
-
-
 
     return (
         <Container>

--- a/client/src/utils.js
+++ b/client/src/utils.js
@@ -11,7 +11,6 @@ const frequencies = {
 const standardDeduction = {
     single: 12550,
     marriedSeparate: 12550,
-    headOfHousehold: 18800,
     marriedJoint: 25100,
 };
 
@@ -58,7 +57,7 @@ export const calculateIncomeTax = (grossIncome, filingStatus) => {
                 full: calculateBracket(0.12, 10276, 41775)
             },
             22: {
-                rate: 0,
+                rate: 0.22,
                 lowerBound: 41776,
                 upperBound: 89075,
                 full: calculateBracket(0.22, 41776, 89075)
@@ -180,7 +179,7 @@ export const calculateIncomeTax = (grossIncome, filingStatus) => {
     let status = brackets[filingStatus];
     let tax = 0;
     for (let bracket in status) {
-        if (remainder > status[bracket].upperBound) {
+        if (deductedIncome > status[bracket].upperBound) {
             remainder = remainder - (status[bracket].upperBound - status[bracket].lowerBound);
             tax = tax + status[bracket].full;
         } else {
@@ -189,11 +188,4 @@ export const calculateIncomeTax = (grossIncome, filingStatus) => {
         }
     }
     return tax;
-}
-
-
-
-
-
-// const headOfHousehold = {
-// };
+};


### PR DESCRIPTION
fixes #39 

There were two problems with the way the app was calculating income that I didn't catch until after I already pushed the latest change:
1. It was _adding_ tax to gross income instead of subtracting - I was just missing a parentheses around an operation
2. The tax calculations were wrong for single rate - turns out I accidently messed up a value while refactoring the tax calculation helper functions

while I was here I also commented out the code for the Dark Mode switch, since it'll be a while before I actually take the time to implement it